### PR TITLE
Fix minor gcc compile errors

### DIFF
--- a/calibration/opengl_widget.cpp
+++ b/calibration/opengl_widget.cpp
@@ -671,9 +671,10 @@ bool OpenGL_Widget::loadConfigFromJson(QString filename)
     QPointF cop;
 
     // Skip the first three lines.
-    fgets(line, sizeof(line), f);
-    fgets(line, sizeof(line), f);
-    fgets(line, sizeof(line), f);
+    char* unused;
+    unused = fgets(line, sizeof(line), f);
+    unused = fgets(line, sizeof(line), f);
+    unused = fgets(line, sizeof(line), f);
 
     // Try and read the red term
     if (fgets(line, sizeof(line), f) == NULL) {
@@ -712,9 +713,9 @@ bool OpenGL_Widget::loadConfigFromJson(QString filename)
     d_k1_blue = val;
 
     // Skip the next three lines
-    fgets(line, sizeof(line), f);
-    fgets(line, sizeof(line), f);
-    fgets(line, sizeof(line), f);
+    unused = fgets(line, sizeof(line), f);
+    unused = fgets(line, sizeof(line), f);
+    unused = fgets(line, sizeof(line), f);
 
     // Try and read the eye X COP term
     if (fgets(line, sizeof(line), f) == NULL) {

--- a/calibration/opengl_widget.h
+++ b/calibration/opengl_widget.h
@@ -128,8 +128,8 @@ protected:
     void setDeftCOPVals();
 
     //Convert point from pixels to relative
-    QPointF OpenGL_Widget::pixelToRelative(QPointF cop);
-    QPoint OpenGL_Widget::relativeToPixel(QPointF cop);
+    QPointF pixelToRelative(QPointF cop);
+    QPoint relativeToPixel(QPointF cop);
 
 private:
     int d_width, d_height;  //< Size of the window we're rendering into

--- a/shaders/undistort_shader.cpp
+++ b/shaders/undistort_shader.cpp
@@ -32,7 +32,7 @@
 class Undistort_Shader_Private
 {
 public:
-    Undistort_Shader_Private::Undistort_Shader_Private()
+    Undistort_Shader_Private()
         : d_shader_id(Undistort_Shader::NO_SHADER) {};
 
     // Read a shader string from a file into a string.  Returns an empty
@@ -101,7 +101,7 @@ std::string Undistort_Shader::readShaderFromFile(std::string filename)
     // TODO: Convert this to using only standard library calls.
     FILE *f = fopen(filename.c_str(), "r");
     if (f == NULL) { 
-        printf("No shader file with name %s found;", filename);
+        printf("No shader file with name %s found;", filename.c_str());
         return ret; }
 
     // Read each line of the file and append it to the string.


### PR DESCRIPTION
Fix minor issues to get it to compile with gcc 4.8.2:
- extra qualification [-fpermissive]
- ignoring return value of char* fgets [-Wunused-result]
- printf with std::string